### PR TITLE
use client id and secret over public key and deprecate public token

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ end
 
 ## Configuration
 
-All calls to Plaid require either your client id and secret, or public key. Add the
-following configuration to your project to set the values. This configuration is optional
+All calls to Plaid require your client id and secret. Public keys are deprecated as of version `2.4`.
+Add the following configuration to your project to set the values. This configuration is optional
 as of version `1.6`, see below for a runtime configuration. The library will raise an
 error if the relevant credentials are not provided either via `config.exs` or at runtime.
 

--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -122,6 +122,7 @@ defmodule Plaid do
   @doc """
   Gets the `public_key` from the config argument or library configuration.
   """
+  @deprecated "Plaid no longer uses public keys for new accounts."
   @spec validate_public_key(map) :: map | no_return
   def validate_public_key(config) do
     %{

--- a/lib/plaid/institutions.ex
+++ b/lib/plaid/institutions.ex
@@ -3,7 +3,7 @@ defmodule Plaid.Institutions do
   Functions for Plaid `institutions` endpoint.
   """
 
-  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1, validate_public_key: 1]
+  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1]
 
   alias Plaid.Utils
 
@@ -124,7 +124,7 @@ defmodule Plaid.Institutions do
   @spec get_by_id(String.t(), config | nil) ::
           {:ok, Plaid.Institutions.Institution.t()} | {:error, Plaid.Error.t()}
   def get_by_id(id, config \\ %{}) do
-    config = validate_public_key(config)
+    config = validate_cred(config)
     params = %{institution_id: id}
     endpoint = "#{@endpoint}/get_by_id"
 
@@ -142,7 +142,7 @@ defmodule Plaid.Institutions do
   """
   @spec search(params, config | nil) :: {:ok, Plaid.Institutions.t()} | {:error, Plaid.Error.t()}
   def search(params, config \\ %{}) do
-    config = validate_public_key(config)
+    config = validate_cred(config)
     endpoint = "#{@endpoint}/search"
 
     make_request_with_cred(:post, endpoint, config, params)

--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -25,7 +25,7 @@ defmodule Plaid.Item do
           item_id: String.t(),
           webhook: String.t(),
           request_id: String.t(),
-          status: map | nil,
+          status: map | nil
         }
   @type params :: %{required(atom) => String.t()}
   @type config :: %{required(atom) => String.t()}
@@ -84,6 +84,7 @@ defmodule Plaid.Item do
   {:ok, %{public_token: "access-env-identifier", expiration: 3600, request_id: "kg414f"}}
   ```
   """
+  @deprecated "Plaid no longer uses public tokens, create a Link token instead."
   @spec create_public_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
   def create_public_token(params, config \\ %{}) do
     config = validate_cred(config)

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Plaid.Mixfile do
   def project do
     [
       app: :plaid,
-      version: "2.4.0",
+      version: "1.7.2",
       description: @description,
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Plaid.Mixfile do
   def project do
     [
       app: :plaid,
-      version: "1.7.2",
+      version: "2.4.0",
       description: @description,
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
This:
1. Stops using `public_key` for auth and instead uses `client_id` and `secret`. Changes for this taken directly from this PR on the original repo: https://github.com/wfgilman/plaid-elixir/commit/124ee49876895c3f6080d30dd5a38818607d1464
2. Deprecates `Plaid.Item.create_public_token` since we now should use `Plaid.Link.create_link_token` instead

This is the last step in Plaid's link token migration before we can fully disable the `public_key` on their dashboard.

https://brexhq.atlassian.net/browse/UW-442