### PR TITLE
Deprecate public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ end
 
 ## Configuration
 
-All calls to Plaid require either your client id and secret, or public key. Add the
-following configuration to your project to set the values. This configuration is optional
+All calls to Plaid require your client id and secret. Public keys are deprecated as of version `2.4` of the upstream project.
+Add the following configuration to your project to set the values. This configuration is optional
 as of version `1.6`, see below for a runtime configuration. The library will raise an
 error if the relevant credentials are not provided either via `config.exs` or at runtime.
 

--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -122,6 +122,7 @@ defmodule Plaid do
   @doc """
   Gets the `public_key` from the config argument or library configuration.
   """
+  @deprecated "Plaid no longer uses public keys for new accounts."
   @spec validate_public_key(map) :: map | no_return
   def validate_public_key(config) do
     %{

--- a/lib/plaid/institutions.ex
+++ b/lib/plaid/institutions.ex
@@ -3,7 +3,7 @@ defmodule Plaid.Institutions do
   Functions for Plaid `institutions` endpoint.
   """
 
-  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1, validate_public_key: 1]
+  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1]
 
   alias Plaid.Utils
 
@@ -133,7 +133,7 @@ defmodule Plaid.Institutions do
   @spec get_by_id(String.t() | params, config | nil) ::
           {:ok, Plaid.Institutions.Institution.t()} | {:error, Plaid.Error.t()}
   def get_by_id(params, config \\ %{}) do
-    config = validate_public_key(config)
+    config = validate_cred(config)
     params = if is_binary(params), do: %{institution_id: params}, else: params
     endpoint = "#{@endpoint}/get_by_id"
 
@@ -151,7 +151,7 @@ defmodule Plaid.Institutions do
   """
   @spec search(params, config | nil) :: {:ok, Plaid.Institutions.t()} | {:error, Plaid.Error.t()}
   def search(params, config \\ %{}) do
-    config = validate_public_key(config)
+    config = validate_cred(config)
     endpoint = "#{@endpoint}/search"
 
     make_request_with_cred(:post, endpoint, config, params)


### PR DESCRIPTION
Plaid has deprecated the use of the public key, and upstream changed to reflect that, this pull in the changes from https://github.com/wfgilman/plaid-elixir/commit/124ee49876895c3f6080d30dd5a38818607d1464