### PR TITLE
[FS-860] Added get_balance_with_httpoison_options and added test case

### DIFF
--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -81,6 +81,20 @@ defmodule Plaid do
   end
 
   @doc """
+  Makes request with credentials and options.
+  """
+  @spec make_request_with_cred_and_options(atom, String.t(), map, map, Keyword.t()) ::
+          {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+  def make_request_with_cred_and_options(method, endpoint, config, body \\ %{}, httpoison_options \\ []) do
+    request_endpoint = "#{get_root_uri(config)}#{endpoint}"
+    cred = Map.delete(config, :root_uri)
+    request_body = Map.merge(body, cred) |> Poison.encode!()
+    request_headers = get_request_headers() |> Map.to_list()
+    options = httpoison_options
+    request(method, request_endpoint, request_body, request_headers, options)
+  end
+
+  @doc """
   Makes request with credentials.
   """
   @spec make_request_with_cred(atom, String.t(), map, map, map, Keyword.t()) ::

--- a/lib/plaid/accounts.ex
+++ b/lib/plaid/accounts.ex
@@ -3,7 +3,7 @@ defmodule Plaid.Accounts do
   Functions for Plaid `accounts` endpoint.
   """
 
-  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1]
+  import Plaid, only: [make_request_with_cred: 4, make_request_with_cred_and_options: 5, validate_cred: 1]
 
   alias Plaid.Utils
 
@@ -17,6 +17,7 @@ defmodule Plaid.Accounts do
         }
   @type params :: %{required(atom) => String.t() | map}
   @type config :: %{required(atom) => String.t()}
+  @type httpoison_options :: %{required(atom) => Keyword.t()}  
 
   @endpoint :accounts
 
@@ -163,7 +164,6 @@ defmodule Plaid.Accounts do
 
   @doc """
   Gets balance for specifed accounts associated with Item.
-
   Parameters
   ```
   %{access_token: "access-token", options: %{account_ids: ["account-id"]}}
@@ -175,6 +175,27 @@ defmodule Plaid.Accounts do
     endpoint = "#{@endpoint}/balance/get"
 
     make_request_with_cred(:post, endpoint, config, params)
+    |> Utils.handle_resp(@endpoint)
+  end
+  
+  @doc """
+  Gets balance with httpoison_options for specifed accounts associated with Item.
+
+  Parameters
+  ```
+  params: %{access_token: "access-token", options: %{account_ids: ["account-id"]}}
+  httpoison_options: [ssl: [{:versions, [:"tlsv1.2"]}],
+                      timeout: 15_000,
+                      recv_timeout: 30_000] 
+  config: could be nil
+  ```
+  """
+  @spec get_balance_with_httpoison_options(params, httpoison_options, config | nil) :: {:ok, Plaid.Accounts.t()} | {:error, Plaid.Error.t()}
+  def get_balance_with_httpoison_options(params, httpoison_options, config \\ %{}) do
+    config = validate_cred(config)
+    endpoint = "#{@endpoint}/balance/get"
+
+    make_request_with_cred_and_options(:post, endpoint, config, params, httpoison_options)
     |> Utils.handle_resp(@endpoint)
   end
 end

--- a/test/lib/plaid/accounts_test.exs
+++ b/test/lib/plaid/accounts_test.exs
@@ -50,5 +50,23 @@ defmodule Plaid.AccountsTest do
       assert Plaid.Accounts == resp.__struct__
       assert {:ok, _} = Jason.encode(resp)
     end
+    
+    test "get_balance_with_options/1 requests POST with longer timeout and returns Plaid.Accounts", %{bypass: bypass} do
+      body = http_response_body(:accounts)
+      httpoison_options = [
+        ssl: [{:versions, [:"tlsv1.2"]}],
+        timeout: 15_000,
+        recv_timeout: 30_000
+      ]
+      Bypass.expect(bypass, fn conn ->
+        assert "POST" == conn.method
+        assert "accounts/balance/get" == Enum.join(conn.path_info, "/")
+        Plug.Conn.resp(conn, 200, Poison.encode!(body))
+      end)
+
+      assert {:ok, resp} = Plaid.Accounts.get_balance_with_httpoison_options(%{access_token: "my-token"}, httpoison_options)
+      assert Plaid.Accounts == resp.__struct__
+      assert {:ok, _} = Jason.encode(resp)
+    end
   end
 end


### PR DESCRIPTION
[https://brex.slack.com/archives/C03C3L9CAQ1/p1666045689311379 - Connect to preview](https://brex.slack.com/archives/C03C3L9CAQ1/p1666045689311379)Plaid's /accounts/balance/get (real-time balance) times out sometimes. Per discussion with bill pay team and Plaid team, we will increase our timeout for this endpoint to 15 seconds, to be the same as bill pay team's timeout. We would still keep the other endpoints at the default timeout of 10 seconds. The new get_balance_with_httpoison_options would support passing in customized httpoison options such as 15 seconds timeout.
https://brexhq.atlassian.net/browse/FS-860
Added test case and tested on dev.
